### PR TITLE
Quick Fix: Treat HouseVendor as Buy

### DIFF
--- a/Crafting/CraftList.cs
+++ b/Crafting/CraftList.cs
@@ -996,6 +996,7 @@ namespace CriticalCommonLib.Crafting
                         return childCrafts;
                     }
                     case IngredientPreferenceType.Buy:
+                    case IngredientPreferenceType.HouseVendor:
                     {
                         if (craftItem.Item.BuyFromVendorPrice != 0)
                         {


### PR DESCRIPTION
Fixes CraftLists computing crafting recipes when Buy from House Vendor is above Crafting.